### PR TITLE
Add New Log Retrieval Endpoints for Users and Cities

### DIFF
--- a/Models/DTOs/UserDTO.cs
+++ b/Models/DTOs/UserDTO.cs
@@ -7,5 +7,6 @@ namespace TravelLogger.Models.DTOs
         public string Email { get; set; }
         public string ImageUrl { get; set; }
         public string Description { get; set; }
+        public List<LogDTO> Logs { get; set; }
     }
 }

--- a/Models/User.cs
+++ b/Models/User.cs
@@ -15,4 +15,5 @@ public class User
     public string ImageUrl { get; set; }
     [Required]
     public string Description { get; set; }
+    public List<Log> Logs { get; set; }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -36,6 +36,43 @@ app.UseCors(options =>
 
 // Add all endpoints here
 
+//LOGS
+//GET all logs for a given user
+app.MapGet("/api/users/{userId}/logs", (TravelLoggerDbContext db, int userId) =>
+{
+    User user = db.Users
+        .Include(u => u.Logs)
+        .SingleOrDefault(u => u.Id == userId);
+
+    if (user == null)
+    {
+        return Results.NotFound();
+    }
+
+    List<LogDTO> userLogs = user.Logs
+        .Select(log => new LogDTO
+        {
+            Id = log.Id,
+            UserId = log.UserId,
+            CityId = log.CityId,
+            Comment = log.Comment,
+            CreatedAt = log.CreatedAt
+        }).ToList();
+
+    UserDTO userDTO = new UserDTO
+    {
+        Id = user.Id,
+        Name = user.Name,
+        Email = user.Email,
+        ImageUrl = user.ImageUrl,
+        Description = user.Description,
+        Logs = userLogs
+    };
+
+    return Results.Ok(userDTO);
+});
+
+
 //RECS
 //GET All Recs (not needed, but good for testing purposes)
 app.MapGet("/api/recommendations", (TravelLoggerDbContext db) =>

--- a/Program.cs
+++ b/Program.cs
@@ -36,7 +36,7 @@ app.UseCors(options =>
 
 // Add all endpoints here
 
-//LOGS
+//LOGS Pt. 2
 //GET all logs for a given user
 app.MapGet("/api/users/{userId}/logs", (TravelLoggerDbContext db, int userId) =>
 {
@@ -72,6 +72,37 @@ app.MapGet("/api/users/{userId}/logs", (TravelLoggerDbContext db, int userId) =>
     return Results.Ok(userDTO);
 });
 
+// GET all logs for a given city
+app.MapGet("/api/cities/{cityId}/logs", (TravelLoggerDbContext db, int cityId) =>
+{
+    City city = db.Cities
+        .Include(c => c.Logs)
+            .ThenInclude(l => l.User)
+        .FirstOrDefault(c => c.Id == cityId);
+
+    if (city == null)
+    {
+        return Results.NotFound();
+    }
+
+    List<LogDTO> logDTOs = city.Logs
+        .Select(log => new LogDTO
+        {
+            Id = log.Id,
+            UserId = log.UserId,
+            CityId = log.CityId,
+            Comment = log.Comment,
+            CreatedAt = log.CreatedAt
+        })
+        .ToList();
+
+    return Results.Ok(new
+    {
+        CityId = city.Id,
+        CityName = city.Name,
+        Logs = logDTOs
+    });
+});
 
 //RECS
 //GET All Recs (not needed, but good for testing purposes)


### PR DESCRIPTION
## 📌 Summary

This PR introduces two new API endpoints that improve the ability to retrieve travel log data by user and by city:

- `GET /api/users/{userId}/logs`: Fetches all logs created by a specific user.
- `GET /api/cities/{cityId}/logs`: Fetches all logs associated with a specific city.

These endpoints are core to enabling personalized user dashboards and city-based content views within the digital nomad travel app.

---

## ✨ New Endpoints

### 1. Get All Logs by User

**Endpoint:** `GET /api/users/{userId}/logs`  
**Description:** Retrieves a user’s profile details (`UserDTO`) along with a list of their travel logs (`LogDTO`s).

**Example Response:**

```json
{
  "id": 1,
  "name": "Jamie Chen",
  "email": "jamie.chen@example.com",
  "imageUrl": "https://example.com/images/jamie.jpg",
  "description": "World traveler and foodie.",
  "logs": [
    {
      "id": 1,
      "userId": 1,
      "cityId": 1,
      "comment": "Tokyo was incredible! Loved the food and the culture.",
      "createdAt": "2025-04-10T00:00:00"
    }
  ]
}
